### PR TITLE
Timeouts, HTTP errors, and malformed responses

### DIFF
--- a/pwned_passwords_django/api.py
+++ b/pwned_passwords_django/api.py
@@ -27,7 +27,7 @@ def pwned_password(password):
         ]
     except (requests.RequestException, ValueError) as e:
         # Gracefully handle timeouts and HTTP error response codes.
-        log.warning('An error occurred checking pwnedpasswords: %s' % e)
+        log.warning('Skipping pwnedpasswords check as an error occurred: %r', e)
         return None
 
     if results:

--- a/pwned_passwords_django/api.py
+++ b/pwned_passwords_django/api.py
@@ -27,7 +27,9 @@ def pwned_password(password):
         ]
     except (requests.RequestException, ValueError) as e:
         # Gracefully handle timeouts and HTTP error response codes.
-        log.warning('Skipping pwnedpasswords check as an error occurred: %r', e)
+        log.warning(
+            'Skipping pwnedpasswords check as an error occurred: %r', e
+        )
         return None
 
     if results:

--- a/pwned_passwords_django/api.py
+++ b/pwned_passwords_django/api.py
@@ -5,6 +5,7 @@ import requests
 
 
 API_ENDPOINT = 'https://api.pwnedpasswords.com/range/{}'
+REQUEST_TIMEOUT = 0.6  # 600ms
 log = logging.getLogger(__name__)
 
 
@@ -20,7 +21,7 @@ def pwned_password(password):
             int(line.partition(':')[2])
             for line in requests.get(
                 url=API_ENDPOINT.format(prefix),
-                timeout=0.6,
+                timeout=REQUEST_TIMEOUT,
             ).text.splitlines()
             if line.startswith(suffix)
         ]

--- a/pwned_passwords_django/api.py
+++ b/pwned_passwords_django/api.py
@@ -25,9 +25,9 @@ def pwned_password(password):
             ).text.splitlines()
             if line.startswith(suffix)
         ]
-    except (requests.RequestException, ValueError):
+    except (requests.RequestException, ValueError) as e:
         # Gracefully handle timeouts and HTTP error response codes.
-        log.exception('Error checking pwnedpasswords')
+        log.warning('An error occurred checking pwnedpasswords: %s' % e)
         return None
 
     if results:

--- a/pwned_passwords_django/api.py
+++ b/pwned_passwords_django/api.py
@@ -1,9 +1,11 @@
 import hashlib
+import logging
 
 import requests
 
 
 API_ENDPOINT = 'https://api.pwnedpasswords.com/range/{}'
+log = logging.getLogger(__name__)
 
 
 def pwned_password(password):
@@ -13,10 +15,19 @@ def pwned_password(password):
     """
     password_hash = hashlib.sha1(password.encode('utf-8')).hexdigest().upper()
     prefix, suffix = password_hash[:5], password_hash[5:]
-    results = [
-        int(line.split(':')[1]) for line in
-        requests.get(API_ENDPOINT.format(prefix)).text.splitlines()
-        if line.startswith(suffix)
-    ]
+    try:
+        results = [
+            int(line.partition(':')[2])
+            for line in requests.get(
+                url=API_ENDPOINT.format(prefix),
+                timeout=0.6,
+            ).text.splitlines()
+            if line.startswith(suffix)
+        ]
+    except (requests.RequestException, ValueError):
+        # Gracefully handle timeouts and HTTP error response codes.
+        log.exception('Error checking pwnedpasswords')
+        return None
+
     if results:
         return results[0]

--- a/pwned_passwords_django/tests/base.py
+++ b/pwned_passwords_django/tests/base.py
@@ -18,3 +18,6 @@ class PwnedPasswordsTests(TestCase):
         requests_get_mock = mock.MagicMock()
         requests_get_mock.return_value.text = response_text
         return requests_get_mock
+
+    def _get_exception_mock(self, exception):
+        return mock.MagicMock(side_effect=exception)

--- a/pwned_passwords_django/tests/test_api.py
+++ b/pwned_passwords_django/tests/test_api.py
@@ -29,7 +29,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
                     url=api.API_ENDPOINT.format(
                         self.sample_password_prefix
                     ),
-                    timeout=0.6,
+                    timeout=api.REQUEST_TIMEOUT,
                 )
                 self.assertEqual(count, result)
 
@@ -49,7 +49,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
                 url=api.API_ENDPOINT.format(
                     self.sample_password_prefix
                 ),
-                timeout=0.6,
+                timeout=api.REQUEST_TIMEOUT,
             )
             self.assertEqual(None, result)
 
@@ -66,7 +66,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
                 url=api.API_ENDPOINT.format(
                     self.sample_password_prefix
                 ),
-                timeout=0.6,
+                timeout=api.REQUEST_TIMEOUT,
             )
             self.assertEqual(0, result)
 
@@ -84,13 +84,13 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
                 url=api.API_ENDPOINT.format(
                     self.sample_password_prefix
                 ),
-                timeout=0.6,
+                timeout=api.REQUEST_TIMEOUT,
             )
             self.assertEqual(None, result)
 
     def test_bad_text(self):
         """
-        Handle non-numeric count gracefully
+        Non-numeric counts in API response are handled gracefully.
 
         """
         request_mock = self._get_mock(
@@ -104,7 +104,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
 
     def test_bad_response_no_colon(self):
         """
-        Handle malformed response with no colon gracefully
+        Malformed API responses with no colon are handled gracefully.
 
         """
         request_mock = self._get_mock(
@@ -116,7 +116,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
 
     def test_bad_response_many_colons(self):
         """
-        Handle malformed response with too many colons gracefully
+        Malformed API responses with too many colons are gracefully.
 
         """
         request_mock = self._get_mock(
@@ -130,20 +130,20 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
 
     def test_timeout(self):
         """
-        Connection timeout response is handled gracefully
+        Connection timeouts to the API are handled gracefully.
 
         """
-        request_mock = mock.MagicMock(side_effect=requests.ConnectTimeout())
+        request_mock = self._get_exception_mock(requests.ConnectTimeout())
         with mock.patch('requests.get', request_mock):
             result = api.pwned_password(self.sample_password)
             self.assertEqual(None, result)
 
     def test_http_error(self):
         """
-        A non-200 HTTP response is handled gracefully
+        non-200 HTTP responses from the API are handled gracefully.
 
         """
-        request_mock = mock.MagicMock(side_effect=requests.HTTPError())
+        request_mock = self._get_exception_mock(requests.HTTPError())
         with mock.patch('requests.get', request_mock):
             result = api.pwned_password(self.sample_password)
             self.assertEqual(None, result)

--- a/pwned_passwords_django/tests/test_middleware.py
+++ b/pwned_passwords_django/tests/test_middleware.py
@@ -3,7 +3,7 @@ import mock
 from django.test import override_settings
 from django.urls import reverse
 
-from ..api import API_ENDPOINT
+from ..api import API_ENDPOINT, REQUEST_TIMEOUT
 
 from .base import PwnedPasswordsTests
 
@@ -39,7 +39,7 @@ class PwnedPasswordsMiddlewareTests(PwnedPasswordsTests):
                     url=API_ENDPOINT.format(
                         self.sample_password_prefix
                     ),
-                    timeout=0.6,
+                    timeout=REQUEST_TIMEOUT,
                 )
 
         for payload in (
@@ -124,7 +124,7 @@ class PwnedPasswordsMiddlewareTests(PwnedPasswordsTests):
                     url=API_ENDPOINT.format(
                         self.sample_password_prefix
                     ),
-                    timeout=0.6,
+                    timeout=REQUEST_TIMEOUT,
                 )
 
         for payload in (

--- a/pwned_passwords_django/tests/test_middleware.py
+++ b/pwned_passwords_django/tests/test_middleware.py
@@ -36,9 +36,10 @@ class PwnedPasswordsMiddlewareTests(PwnedPasswordsTests):
             with mock.patch('requests.get', request_mock):
                 self.client.post(self.test_url, data=payload)
                 request_mock.assert_called_with(
-                    API_ENDPOINT.format(
+                    url=API_ENDPOINT.format(
                         self.sample_password_prefix
-                    )
+                    ),
+                    timeout=0.6,
                 )
 
         for payload in (
@@ -120,9 +121,10 @@ class PwnedPasswordsMiddlewareTests(PwnedPasswordsTests):
             with mock.patch('requests.get', request_mock):
                 self.client.post(self.test_url, data=payload)
                 request_mock.assert_called_with(
-                    API_ENDPOINT.format(
+                    url=API_ENDPOINT.format(
                         self.sample_password_prefix
-                    )
+                    ),
+                    timeout=0.6,
                 )
 
         for payload in (

--- a/pwned_passwords_django/tests/test_validators.py
+++ b/pwned_passwords_django/tests/test_validators.py
@@ -36,7 +36,7 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
                     url=api.API_ENDPOINT.format(
                         self.sample_password_prefix
                     ),
-                    timeout=0.6,
+                    timeout=api.REQUEST_TIMEOUT,
                 )
 
     def test_not_compromised(self):
@@ -55,5 +55,5 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
                 url=api.API_ENDPOINT.format(
                     self.sample_password_prefix
                 ),
-                timeout=0.6,
+                timeout=api.REQUEST_TIMEOUT,
             )

--- a/pwned_passwords_django/tests/test_validators.py
+++ b/pwned_passwords_django/tests/test_validators.py
@@ -33,9 +33,10 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
                 ):
                     validate_password(self.sample_password)
                 request_mock.assert_called_with(
-                    api.API_ENDPOINT.format(
+                    url=api.API_ENDPOINT.format(
                         self.sample_password_prefix
-                    )
+                    ),
+                    timeout=0.6,
                 )
 
     def test_not_compromised(self):
@@ -51,7 +52,8 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
         with mock.patch('requests.get', request_mock):
             validate_password(self.sample_password)
             request_mock.assert_called_with(
-                api.API_ENDPOINT.format(
+                url=api.API_ENDPOINT.format(
                     self.sample_password_prefix
-                )
+                ),
+                timeout=0.6,
             )


### PR DESCRIPTION
I have added a timeout, and some exception handling.
When an exception occurs, it will return a None response, so the application continue to work during downtime of the pwnedpasswords API.

Handled cases:

- Request timeout (Connection and waiting for response, not including download of response time)
- HTTP error (for example a 502 from the CDN)
- Malformed response
  - Non-numeric count value
  - No colon, or too many colons in the response. (using `.partition` instead of `.split`)


I have not used the API much yet, so I am unsure if 600ms is adequate, let me know if it should be longer.