### PR TITLE
Allow overriding of messages

### DIFF
--- a/docs/validator.rst
+++ b/docs/validator.rst
@@ -46,3 +46,39 @@ Using the password validator
    changes a user's password in other ways. If you manipulate user
    passwords through means other than the high-level APIs listed
    above, you'll need to manually check passwords.
+
+
+Changing the error message
+==========================
+
+To change the error or help message shown to the user, you can set it
+in the ``OPTIONS`` dictionary like so:
+
+.. code-block:: python
+
+   AUTH_PASSWORD_VALIDATORS = [
+       {
+           'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
+           'OPTIONS': {
+               'error_message': 'That password was pwned',
+               'help_message': 'Your password can\'t be a commonly used password.',
+           }
+       },
+   ]
+
+The amount of times the password has appeared in a breach can also be included
+in the error message, including a plural form:
+
+.. code-block:: python
+
+   AUTH_PASSWORD_VALIDATORS = [
+       {
+           'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
+           'OPTIONS': {
+               'error_message': (
+                  'Pwned %(amount)d time',
+                  'Pwned %(amount)d times',
+               )
+           }
+       },
+   ]

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ungettext
 
 from . import api
 
@@ -9,14 +9,34 @@ class PwnedPasswordsValidator(object):
     Password validator which checks the Pwned Passwords database.
 
     """
-    HELP_MESSAGE = _("Your password can't be a commonly used password.")
-    PWNED_MESSAGE = _(
+    DEFAULT_HELP_MESSAGE = _(
+        "Your password can't be a commonly used password."
+    )
+    DEFAULT_PWNED_MESSAGE = (
         "This password is known to have appeared in a public data breach."
     )
 
+    def __init__(self, error_message=None, help_message=None):
+        self.help_message = help_message or self.DEFAULT_HELP_MESSAGE
+        error_message = error_message or self.DEFAULT_PWNED_MESSAGE
+        # If there is no plural, use the same message for both forms
+        if not isinstance(error_message, (list, tuple)):
+            self.error_message = (error_message, error_message)
+        else:
+            self.error_message = error_message
+
     def validate(self, password, user=None):
-        if api.pwned_password(password):
-            raise ValidationError(self.PWNED_MESSAGE, code='pwned_password')
+        amount = api.pwned_password(password)
+        if amount:
+            raise ValidationError(
+                ungettext(
+                    self.error_message[0],
+                    self.error_message[1],
+                    amount,
+                ),
+                params={'amount': amount},
+                code='pwned_password',
+            )
 
     def get_help_text(self):
-        return self.HELP_MESSAGE  # pragma: no cover
+        return self.help_message  # pragma: no cover

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -16,7 +16,7 @@ class PwnedPasswordsValidator(object):
 
     def validate(self, password, user=None):
         if api.pwned_password(password):
-            raise ValidationError(self.PWNED_MESSAGE)
+            raise ValidationError(self.PWNED_MESSAGE, code='pwned_password')
 
     def get_help_text(self):
         return self.HELP_MESSAGE  # pragma: no cover

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _, ungettext
+from django.utils.translation import ugettext as _
+from django.utils.translation import ungettext
 
 from . import api
 


### PR DESCRIPTION
## Add code for use as a field validator
Set the code of the ValidationError for pwned passwords to `pwned_password`, to allow the use of `error_messages` when used in a field as a regular validator.

See: https://docs.djangoproject.com/en/2.0/ref/forms/validation/#raising-validationerror
See: https://docs.djangoproject.com/en/2.0/ref/forms/fields/#error-messages

Example:

```python
def pwned_validator(password):
    PwnedPasswordsValidator().validate(password)

class ChangePassword(forms.Form):
    forms.CharField(
        validators=[pwned_validator],
        error_messages={
            'pwned_password': 'Example message',
        }
    )
```

## Override messages in Django settings
Unfortunately you cannot override messages like the above when used in a `clean_*` method (like the default Django change password form).
So I also added a way to override it in the `OPTIONS` of the validator in the settings.
You can also put the number of times the password appeared in breaches with the `%(amount)d` syntax, and even an optional plural form.

For example:

```python
{
    'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
    'OPTIONS': {
        'error_message': 'That password was pwned',
        'help_message': 'Cannot be pwned password',
    },
}
```

With count (and plural form):

```python
{
    'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
    'OPTIONS': {
        'error_message': (
                'Pwned %(amount)d time',
                'Pwned %(amount)d times',
        ),
    },
}
```