### PR TITLE
Adding a configurable timeout

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,4 +16,6 @@ directly check a password against Pwned Passwords.
 
    :param password: The password to check.
    :type password: ``str``
+   :param timeout: Optional timeout in seconds. Defaults to 0.6 seconds.
+   :type timeout: ``float``
    :rtype: ``int`` or ``None``

--- a/docs/validator.rst
+++ b/docs/validator.rst
@@ -46,3 +46,24 @@ Using the password validator
    changes a user's password in other ways. If you manipulate user
    passwords through means other than the high-level APIs listed
    above, you'll need to manually check passwords.
+
+
+Configuration options
+=====================
+
+You can change several options on the validator via the ``OPTIONS`` key on the validation entry in the
+``AUTH_PASSWORD_VALIDATORS`` setting.
+
+
+   .. code-block:: python
+
+      AUTH_PASSWORD_VALIDATORS = [
+          {
+              'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
+              'OPTIONS': {
+                  'timeout': 0.6,
+              },
+          },
+      ]
+
+* ``timeout`` changes the request timeout to the API, in seconds. Defaults to 0.6 seconds.

--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -19,7 +19,7 @@ USER_AGENT = 'pwned-passwords-django/{} (Python/{} | Django/{})'.format(
 log = logging.getLogger(__name__)
 
 
-def pwned_password(password):
+def pwned_password(password, timeout=REQUEST_TIMEOUT):
     """
     Checks a password against the Pwned Passwords database.
 
@@ -32,7 +32,7 @@ def pwned_password(password):
             for line in requests.get(
                     url=API_ENDPOINT.format(prefix),
                     headers={'User-Agent': USER_AGENT},
-                    timeout=REQUEST_TIMEOUT,
+                    timeout=timeout,
             ).text.splitlines()
             if line.startswith(suffix)
         ]

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -14,8 +14,11 @@ class PwnedPasswordsValidator(object):
         "This password is known to have appeared in a public data breach."
     )
 
+    def __init__(self, timeout=api.REQUEST_TIMEOUT):
+        self.timeout = timeout
+
     def validate(self, password, user=None):
-        if api.pwned_password(password):
+        if api.pwned_password(password, timeout=self.timeout):
             raise ValidationError(self.PWNED_MESSAGE)
 
     def get_help_text(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,3 +151,19 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
         with mock.patch('requests.get', request_mock):
             result = api.pwned_password(self.sample_password)
             self.assertEqual(None, result)
+
+    def test_timeout_option(self):
+        """
+        timeout parameter is passed to requests
+
+        """
+        request_mock = self._get_mock()
+        with mock.patch('requests.get', request_mock):
+            api.pwned_password(self.sample_password, timeout=5)
+            request_mock.assert_called_with(
+                url=api.API_ENDPOINT.format(
+                    self.sample_password_prefix
+                ),
+                headers=self.user_agent,
+                timeout=5,
+            )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,7 @@
 import mock
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 
 from pwned_passwords_django import api
 from pwned_passwords_django.validators import PwnedPasswordsValidator
@@ -57,4 +58,28 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
                 ),
                 headers=self.user_agent,
                 timeout=api.REQUEST_TIMEOUT,
+            )
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
+        'OPTIONS': {'timeout': 4},
+    }])
+    def test_timeout_option(self):
+        """
+        timeout option is passed down to requests.
+
+        """
+        request_mock = self._get_mock(
+            response_text='{}:5'.format(
+                self.sample_password_suffix.replace('A', '3')
+            )
+        )
+        with mock.patch('requests.get', request_mock):
+            validate_password(self.sample_password)
+            request_mock.assert_called_with(
+                url=api.API_ENDPOINT.format(
+                    self.sample_password_prefix
+                ),
+                headers=self.user_agent,
+                timeout=4,
             )


### PR DESCRIPTION
Make the timeout on the API configurable, fixes #7 

To set the option, just change the value in the `OPTIONS` dictionary like this:

```python
    'AUTH_PASSWORD_VALIDATORS': [
        {
            'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
            'OPTOINS': {
                'timeout': 1,
            },
        },
    ],
```
The timeout option is in seconds.