### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
    enchant
 language: python
 sudo: false
+cache: pip
 python:
  - "3.6"
  - "3.5"


### PR DESCRIPTION
Slightly speed up builds and reduce load on PyPI servers.

For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache