### PR TITLE
Add a fallback mechanism after a HIBP API failure

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ New features:
 * When a request to the Pwned Passwords API times out, or encounters
   an error, it now logs a warning and skips the Pwned Passwords check.
 
+* In the event of a HIBP API failure, the Pwned Passwords validator now falls
+  back to Django's ``CommonPasswordValidator``.
+
 Bugs fixed:
 ~~~~~~~~~~~
 

--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -64,4 +64,4 @@ def pwned_password(password):
     if results is None:
         # Gracefully handle timeouts and HTTP error response codes.
         return None
-    return results.get(suffix)
+    return results.get(suffix, 0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,7 +58,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
                 headers=self.user_agent,
                 timeout=api.REQUEST_TIMEOUT,
             )
-            self.assertEqual(None, result)
+            self.assertEqual(0, result)
 
         # The real API doesn't return a result with a zero count, but
         # test it just in case.
@@ -95,7 +95,7 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
                 headers=self.user_agent,
                 timeout=api.REQUEST_TIMEOUT,
             )
-            self.assertEqual(None, result)
+            self.assertEqual(0, result)
 
     @override_settings(PWNED_PASSWORDS_API_TIMEOUT=0.5)
     def test_timeout_override(self):


### PR DESCRIPTION
Previously, in the event of a HIBP API failure, the password was assumed to be valid. Instead of allowing a potentially compromised password, fallback to checking against Django's list of common passwords. While an incomplete list, the passwords are generated from the same HIBP database.

Details on Django's list of common passwords can be seen at:

https://docs.djangoproject.com/en/2.0/topics/auth/passwords/#django.contrib.auth.password_validation.CommonPasswordValidator