### PR TITLE
Add a cache

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -42,6 +42,8 @@ SETTINGS_DICT = {
             'NAME': 'pwned_passwords_django.validators.PwnedPasswordsValidator',
         },
     ],
+    # Dont cache in tests
+    'PWNED_PASSWORDS_CACHE': False,
     'LOGGING': {
         'version': 1,
         'disable_existing_loggers': True,

--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -4,6 +4,7 @@ import sys
 
 import requests
 from django.conf import settings
+from django.core.cache import caches
 from django.utils.six import text_type
 
 from . import __version__
@@ -13,6 +14,7 @@ log = logging.getLogger(__name__)
 
 API_ENDPOINT = 'https://api.pwnedpasswords.com/range/{}'
 REQUEST_TIMEOUT = 1.0  # 1 second
+DEFAULT_CACHE_TIMEOUT = 60 * 60  # 1 hour
 USER_AGENT = 'pwned-passwords-django/{} (Python/{} | requests/{})'.format(
     __version__,
     '{}.{}.{}'.format(*sys.version_info[:3]),
@@ -20,35 +22,78 @@ USER_AGENT = 'pwned-passwords-django/{} (Python/{} | requests/{})'.format(
 )
 
 
-def pwned_password(password):
+def hash_password(password):
     """
-    Checks a password against the Pwned Passwords database.
+    Get the SHA-1 k-anonymity prefix and suffix of a password.
 
     """
     if not isinstance(password, text_type):
         raise TypeError('Password values to check must be Unicode strings.')
     password_hash = hashlib.sha1(password.encode('utf-8')).hexdigest().upper()
     prefix, suffix = password_hash[:5], password_hash[5:]
+    return prefix, suffix
+
+
+def get_pwned_list(prefix):
+    """
+    Get the list of all pwned password hashes for a given SHA-1 prefix.
+
+    """
     try:
-        results = [
-            int(line.partition(':')[2])
-            for line in requests.get(
-                    url=API_ENDPOINT.format(prefix),
-                    headers={'User-Agent': USER_AGENT},
-                    timeout=getattr(
-                        settings,
-                        'PWNED_PASSWORDS_API_TIMEOUT',
-                        REQUEST_TIMEOUT
-                    ),
-            ).text.splitlines()
-            if line.startswith(suffix)
-        ]
-    except (requests.RequestException, ValueError) as e:
+        response = requests.get(
+            url=API_ENDPOINT.format(prefix),
+            headers={'User-Agent': USER_AGENT},
+            timeout=getattr(
+                settings,
+                'PWNED_PASSWORDS_API_TIMEOUT',
+                REQUEST_TIMEOUT
+            ),
+        )
+        response.raise_for_status()
+    except requests.RequestException as e:
         # Gracefully handle timeouts and HTTP error response codes.
         log.warning(
             'Skipped Pwned Passwords check due to error: %r', e
         )
         return None
+    result = {}
+    for line in response.text.splitlines():
+        try:
+            suffix, _, times = line.partition(':')
+            result[suffix] = int(times)
+        except ValueError as e:
+            log.warning('Invalid value in Pwned Passwords API: %r', e)
+            pass
+    return result
 
-    if results:
-        return results[0]
+
+def pwned_password(password):
+    """
+    Checks a password against the Pwned Passwords database.
+
+    """
+    prefix, suffix = hash_password(password)
+    cache_name = getattr(settings, 'PWNED_PASSWORDS_CACHE_NAME', 'default')
+    cache_key = 'pwned:{}'.format(prefix)
+    use_cache = getattr(settings, 'PWNED_PASSWORDS_CACHE', True)
+
+    if use_cache:
+        results = caches[cache_name].get(cache_key)
+    else:
+        results = None
+
+    if results is None:
+        results = get_pwned_list(prefix)
+        if use_cache:
+            caches[cache_name].set(
+                cache_key,
+                results,
+                timeout=getattr(
+                    settings,
+                    'PWNED_PASSWORDS_CACHE_TIMEOUT',
+                    DEFAULT_CACHE_TIMEOUT
+                )
+            )
+
+    if results is not None:
+        return results.get(suffix)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,3 +173,27 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
         with mock.patch('requests.get', request_mock):
             result = api.pwned_password(self.sample_password)
             self.assertEqual(None, result)
+
+    @override_settings(PWNED_PASSWORDS_CACHE=True)
+    def test_cache_duplicate_prefix(self):
+        """
+        Duplicate requests are cached
+
+        """
+        request_mock = self._get_mock()
+        with mock.patch('requests.get', request_mock):
+            api.pwned_password(self.sample_password)
+            api.pwned_password(self.sample_password)
+        request_mock.assert_called_once()
+
+    @override_settings(PWNED_PASSWORDS_CACHE=True)
+    def test_no_cache_when_different(self):
+        """
+        Don't cache when the password hash prefix is different
+
+        """
+        request_mock = self._get_mock()
+        with mock.patch('requests.get', request_mock):
+            api.pwned_password(self.sample_password)
+            api.pwned_password('anotherpassword')
+        self.assertEqual(2, len(request_mock.mock_calls))


### PR DESCRIPTION
Add a cache for each hash prefix to avoid making a request on every check.

## Configuration options
`PWNED_PASSWORDS_CACHE`: Turns on and off the cache. Default True.
`PWNED_PASSWORDS_CACHE_NAME`: Which Django cache to use. Default "default".
`PWNED_PASSWORDS_CACHE_TIMEOUT`: How long to cache for in seconds. Default 1 hour.