### PR TITLE
Remove handling for malformed 200 response

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,8 +22,7 @@ New features:
   :data:`~django.conf.settings.PWNED_PASSWORDS_API_TIMEOUT`.
 
 * When a request to the Pwned Passwords API times out, or encounters
-  an error or a response in an unexpected format, it now logs a
-  warning and skips the Pwned Passwords check.
+  an error, it now logs a warning and skips the Pwned Passwords check.
 
 Bugs fixed:
 ~~~~~~~~~~~

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,46 +97,6 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
             )
             self.assertEqual(None, result)
 
-    def test_bad_text(self):
-        """
-        Non-numeric counts in API response are handled gracefully.
-
-        """
-        request_mock = self._get_mock(
-            response_text='{}:xxx'.format(
-                self.sample_password_suffix
-            )
-        )
-        with mock.patch('requests.get', request_mock):
-            result = api.pwned_password(self.sample_password)
-            self.assertEqual(None, result)
-
-    def test_bad_response_no_colon(self):
-        """
-        Malformed API responses with no colon are handled gracefully.
-
-        """
-        request_mock = self._get_mock(
-            response_text=self.sample_password_suffix
-        )
-        with mock.patch('requests.get', request_mock):
-            result = api.pwned_password(self.sample_password)
-            self.assertEqual(None, result)
-
-    def test_bad_response_many_colons(self):
-        """
-        Malformed API responses with too many colons are gracefully.
-
-        """
-        request_mock = self._get_mock(
-            response_text='{}:123:xxx'.format(
-                self.sample_password_suffix
-            )
-        )
-        with mock.patch('requests.get', request_mock):
-            result = api.pwned_password(self.sample_password)
-            self.assertEqual(None, result)
-
     @override_settings(PWNED_PASSWORDS_API_TIMEOUT=0.5)
     def test_timeout_override(self):
         """
@@ -170,6 +130,10 @@ class PwnedPasswordsAPITests(PwnedPasswordsTests):
 
         """
         request_mock = self._get_exception_mock(requests.HTTPError())
-        with mock.patch('requests.get', request_mock):
+        with mock.patch.object(
+                requests.Response,
+                'raise_for_status',
+                request_mock
+        ):
             result = api.pwned_password(self.sample_password)
             self.assertEqual(None, result)


### PR DESCRIPTION
It is reasonable to expect that, from time to time, HIBP will timeout or require maintenance and return a non-200 response.

However, given a 200 response, we should be confident that HIBP is honoring its API and returning a body in the expected, documented format. Therefore, remove the added complexity to handle such a error case. Remove all non-representative tests.