### PR TITLE
Match DEFAULT_HELP_MESSAGE to Django's CommonPasswordValidator

### DIFF
--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -13,14 +13,15 @@ from django.utils.translation import ungettext
 from . import api
 
 
+common_password_validator = CommonPasswordValidator()
+
+
 class PwnedPasswordsValidator(object):
     """
     Password validator which checks the Pwned Passwords database.
 
     """
-    DEFAULT_HELP_MESSAGE = _(
-        "Your password can't be a commonly used password."
-    )
+    DEFAULT_HELP_MESSAGE = common_password_validator.get_help_text()
     DEFAULT_PWNED_MESSAGE = _(
         "This password is too common."
     )
@@ -45,7 +46,7 @@ class PwnedPasswordsValidator(object):
             # HIBP API failure. Instead of allowing a potentially compromised
             # password, check Django's list of common passwords generated from
             # the same database.
-            CommonPasswordValidator().validate(password, user)
+            common_password_validator.validate(password, user)
         elif amount:
             raise ValidationError(
                 ungettext(

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,7 @@
 import mock
 import requests
-from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.password_validation import (CommonPasswordValidator,
+                                                     validate_password)
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 
@@ -154,3 +155,9 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
             else:
                 # If no validation error was raised, that's a failure.
                 assert False
+
+    def test_get_help_text_matches_django(self):
+        self.assertEqual(
+            PwnedPasswordsValidator().get_help_text(),
+            CommonPasswordValidator().get_help_text()
+        )


### PR DESCRIPTION
Django recently updated the help text of CommonPasswordValidator. For
details, see the upstream commit:

https://github.com/django/django/commit/42b9a23267f14be39b9b00958e18d5746783208e

Rather than copy and paste the help text every time it is updated,
directly reuse the value from CommonPasswordValidator.

This has the side effect of using a single instance of
CommonPasswordValidator instead of re-instantiating it every time it is
needed.