### PR TITLE
Use ugettext_lazy to prevent wrong translations

### DIFF
--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -6,8 +6,8 @@ compromised passwords.
 
 from django.contrib.auth.password_validation import CommonPasswordValidator
 from django.core.exceptions import ValidationError
-from django.utils.six import string_types
 from django.utils.functional import Promise
+from django.utils.six import string_types
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -7,7 +7,7 @@ compromised passwords.
 from django.contrib.auth.password_validation import CommonPasswordValidator
 from django.core.exceptions import ValidationError
 from django.utils.six import string_types
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
 from . import api

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -7,6 +7,7 @@ compromised passwords.
 from django.contrib.auth.password_validation import CommonPasswordValidator
 from django.core.exceptions import ValidationError
 from django.utils.six import string_types
+from django.utils.functional import Promise
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
@@ -31,7 +32,7 @@ class PwnedPasswordsValidator(object):
         error_message = error_message or self.DEFAULT_PWNED_MESSAGE
 
         # If there is no plural, use the same message for both forms.
-        if isinstance(error_message, string_types):
+        if isinstance(error_message, (string_types, Promise)):
             singular, plural = error_message, error_message
         else:
             singular, plural = error_message

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -31,7 +31,7 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
             with mock.patch('requests.get', request_mock):
                 with self.assertRaisesMessage(
                         ValidationError,
-                        PwnedPasswordsValidator.DEFAULT_PWNED_MESSAGE
+                        str(PwnedPasswordsValidator.DEFAULT_PWNED_MESSAGE)
                 ):
                     validate_password(self.sample_password)
                 request_mock.assert_called_with(
@@ -66,7 +66,7 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
         validator = PwnedPasswordsValidator()
         self.assertEqual(
             validator.get_help_text(),
-            validator.DEFAULT_HELP_MESSAGE
+            str(validator.DEFAULT_HELP_MESSAGE)
         )
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
@@ -146,7 +146,7 @@ class PwnedPasswordsValidatorsTests(PwnedPasswordsTests):
                 # PwnedPasswordsValidator.
                 self.assertEqual(
                     error.message,
-                    PwnedPasswordsValidator.DEFAULT_PWNED_MESSAGE
+                    str(PwnedPasswordsValidator.DEFAULT_PWNED_MESSAGE)
                 )
                 self.assertEqual(
                     error.code,


### PR DESCRIPTION
![cached_translation](https://user-images.githubusercontent.com/11520139/68775740-4d664900-062f-11ea-9e62-a9d057328ec1.png)
