### PR TITLE
Remove 'universal = 1' from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE
 


### PR DESCRIPTION
Now that the package does not support Python 2, it is no longer a
"universal" wheel.

From https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels

> If your project … is expected to work on both Python 2 and 3 …