### PR TITLE
Replace deprecated translation functions

### DIFF
--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -11,8 +11,8 @@ from django.contrib.auth.password_validation import CommonPasswordValidator
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 from django.utils.functional import Promise
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from . import api
 
@@ -57,7 +57,7 @@ class PwnedPasswordsValidator:
             common_password_validator.validate(password, user)
         elif amount:
             raise ValidationError(
-                ungettext(
+                ngettext(
                     self.error_message["singular"], self.error_message["plural"], amount
                 ),
                 params={"amount": amount},


### PR DESCRIPTION
Fixes Django warning of the form:

    .../pwned_passwords_django/validators.py:34: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
      DEFAULT_PWNED_MESSAGE = _("This password is too common.")

The u variants only make a difference on Python 2, which is no longer
supported.

These functions were deprecated in the upstream commit:
https://github.com/django/django/commit/6eb4996672ca5ccaba20e468d91a83d1cd019801