### PR TITLE
Add Django master branch to the test matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.5",
-    install_requires=["Django>=2.2,<3.1", "requests"],
+    install_requires=["Django>=2.2", "requests"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
   {py35}-django{22}
-  {py36,py37,py38}-django{22,30}
+  {py36,py37,py38}-django{22,30,master}
   black
   docs
   flake8
@@ -99,6 +99,7 @@ deps =
   coverage
   django22: Django>=2.2,<3.0
   django30: Django>=3.0,<3.1
+  djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [travis]
 python =


### PR DESCRIPTION
This helps ensure that the project remains compatible with Django as
either evolves. When it gets close to the next Django release,
pwned-passwords-django will be in a more compatible position as it will
have continuously tested against the master branch.

Dropping the upper bound also allows projects which depend on both
Django and pwned-passwords-django to test against the Django master
branch without a version conflict.