### PR TITLE
Simplify isort and flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,17 +2,9 @@
 fail_under = 100
 
 [flake8]
-exclude = locale,__pycache__,.pyc,templates
-ignore =
-  E203,
-  W503,
-  W504
+extend-ignore = E203
 max-complexity = 10
 max-line-length = 88
 
 [isort]
-include_trailing_comma = True
-known_first_party = pwned_passwords_django
-known_third_party = django,mock,requests
-lines_after_imports = 2
-multi_line_output = 3
+profile = black

--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -14,7 +14,6 @@ from django.conf import settings
 
 from . import __version__
 
-
 log = logging.getLogger(__name__)
 
 API_ENDPOINT = "https://api.pwnedpasswords.com/range/{}"

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -16,7 +16,6 @@ from django.utils.translation import ngettext
 
 from . import api
 
-
 StrOrTranslation = Union[str, Promise]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,10 +70,10 @@ commands =
 
 [testenv:isort]
 changedir = {toxinidir}
-deps = isort
+deps = isort>=5.0.1
 commands =
   {[pipupgrade]commands}
-  isort --recursive --check-only --diff {toxinidir}/src/pwned_passwords_django {toxinidir}/tests
+  isort --check-only --diff {toxinidir}/src/pwned_passwords_django {toxinidir}/tests
   {[cleanup]commands}
 
 [testenv:mypy]


### PR DESCRIPTION
- Flake8 W503,W504 are ignored by default
- Flake8 excludes common patterns by default
- isort is now recursive by default since 5.*
- Use isort profile feature to use match black formatting