### PR TITLE
Include py.typed for PEP 561 complicance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     url="https://github.com/ubernostrum/pwned-passwords-django/",
     packages=find_packages("src"),
     package_dir={"": "src"},
+    package_data={"pwned_passwords_django": ["py.typed"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
See:
https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages

> If you would like to publish a library package to a package
> repository (e.g. PyPI) for either internal or external use in type
> checking, packages that supply type information via type comments or
> annotations in the code should put a py.typed file in their package
> directory.