### PR TITLE
Include `py.typed` so type annotations are exported

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,11 @@ Changelog
 This document lists changes between released versions of
 pwned-passwords-django.
 
-2.0 -- released 2023-??-??
+Unreleased
+----------
+Exports type hints for consumption by ``mypy`` and other typecheckers.
+
+2.0 -- released 2023-03-26
 --------------------------
 
 Major version bump. Much of the codebase has been rewritten and improved.

--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -73,7 +73,7 @@ class PwnedPasswords:
         self,
         client: typing.Optional[httpx.Client] = None,
         async_client: typing.Optional[httpx.AsyncClient] = None,
-    ):
+    ) -> None:
         settings_dict = getattr(settings, "PWNED_PASSWORDS", {})
         self.request_timeout = httpx.Timeout(
             settings_dict.get("API_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)

--- a/src/pwned_passwords_django/exceptions.py
+++ b/src/pwned_passwords_django/exceptions.py
@@ -23,7 +23,7 @@ class PwnedPasswordsError(Exception):
 
     """
 
-    def __init__(self, message: str, code: ErrorCode, params: dict):
+    def __init__(self, message: str, code: ErrorCode, params: dict) -> None:
         super().__init__(message, code, params)
         self.message = message
         self.code = code

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -40,7 +40,7 @@ class PwnedPasswordsValidator:
         error_message: typing.Optional[PluralMessage] = None,
         help_message: typing.Optional[Message] = None,
         api_client: api.PwnedPasswords = api.default_client,
-    ):
+    ) -> None:
         self.fallback_validator = CommonPasswordValidator()
         self.help_message = help_message or self.fallback_validator.get_help_text()
         error_message = error_message or self.default_error_message


### PR DESCRIPTION
Include `py.typed` so type annotations are exported

Per PEP 561, this file must be included so that the excellent type hints
in this package can be consumed by third parties!

https://peps.python.org/pep-0561/#packaging-type-information

Quick testing locally with `setuptools` and `build` indicates to me that
this file is distributed in the resulting wheel (meaning that the module
can be typechecked), but you should confirm this with your own
distribution processes!

One extra change: Complete `__init__` annotations
=================================================

I can make this a separate PR if desired!

Also, while we're at it, explicitly annotate the return type of
`__init__`, which is required by PEP 484:

> (Note that the return type of `__init__` ought to be annotated with
> `-> None`. The reason for this is subtle. If `__init__` assumed a
> return annotation of `-> None`, would that mean that an argument-less,
> un-annotated `__init__` method should still be type-checked? Rather
> than leaving this ambiguous or introducing an exception to the
> exception, we simply say that `__init__` ought to have a return
> annotation; the default behavior is thus the same as for other
> methods.)

https://peps.python.org/pep-0484/