### PR TITLE
Annotate return type of `__init__`

### DIFF
--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -73,7 +73,7 @@ class PwnedPasswords:
         self,
         client: typing.Optional[httpx.Client] = None,
         async_client: typing.Optional[httpx.AsyncClient] = None,
-    ):
+    ) -> None:
         settings_dict = getattr(settings, "PWNED_PASSWORDS", {})
         self.request_timeout = httpx.Timeout(
             settings_dict.get("API_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)

--- a/src/pwned_passwords_django/exceptions.py
+++ b/src/pwned_passwords_django/exceptions.py
@@ -23,7 +23,7 @@ class PwnedPasswordsError(Exception):
 
     """
 
-    def __init__(self, message: str, code: ErrorCode, params: dict):
+    def __init__(self, message: str, code: ErrorCode, params: dict) -> None:
         super().__init__(message, code, params)
         self.message = message
         self.code = code

--- a/src/pwned_passwords_django/validators.py
+++ b/src/pwned_passwords_django/validators.py
@@ -40,7 +40,7 @@ class PwnedPasswordsValidator:
         error_message: typing.Optional[PluralMessage] = None,
         help_message: typing.Optional[Message] = None,
         api_client: api.PwnedPasswords = api.default_client,
-    ):
+    ) -> None:
         self.fallback_validator = CommonPasswordValidator()
         self.help_message = help_message or self.fallback_validator.get_help_text()
         error_message = error_message or self.default_error_message


### PR DESCRIPTION
Per PEP 484, annotating the return type of `__init__` is required (even
though it should *always* be `None`), since that's the only way to
differentiate the method definition from a method without annotation:

> (Note that the return type of `__init__` ought to be annotated with
> `-> None`. The reason for this is subtle. If `__init__` assumed a
> return annotation of `-> None`, would that mean that an argument-less,
> un-annotated `__init__` method should still be type-checked? Rather
> than leaving this ambiguous or introducing an exception to the
> exception, we simply say that `__init__` ought to have a return
> annotation; the default behavior is thus the same as for other
> methods.)

https://peps.python.org/pep-0484/