### PR TITLE
Add setting to configure API base URL

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -20,6 +20,7 @@ module:
       PWNED_PASSWORDS = {
          "ADD_PADDING": True,
          "API_TIMEOUT": 1.0,
+         "API_ENDPOINT": "https://api.pwnedpasswords.com/range/",
          "PASSWORD_REGEX": r"PASS",
       }
 
@@ -48,6 +49,16 @@ module:
       contacting Pwned Passwords, in seconds.
 
       Default value, if not provided, is ``1.0`` (one second).
+
+   **API_ENDPOINT**
+      A :class:`str` indicating the base URL of the Pwned Passwords API.
+
+      Customizing this setting is useful, for example, when `self-hosting
+      <https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction>`_ the
+      API.
+
+      Default value, if not provided, is the URL of the official service
+      hosted by Troy Hunt (``"https://api.pwnedpasswords.com/range/"``).
 
    **PASSWORD_REGEX**
       A :class:`str` -- *not* a compiled regex object -- to be used as a regex

--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -81,6 +81,7 @@ class PwnedPasswords:
         self.add_padding = settings_dict.get("ADD_PADDING", True)
         self.client = client or httpx.Client()
         self.async_client = async_client or httpx.AsyncClient()
+        self.api_endpoint = settings_dict.get("API_ENDPOINT", self.api_endpoint)
 
     def _prepare_password(self, password: str) -> typing.Tuple[str, str]:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -166,6 +166,15 @@ class PwnedPasswordsAPITests(base.PwnedPasswordsTests):
             url=mock.ANY, headers=mock.ANY, timeout=httpx.Timeout(0.5)
         )
 
+    @override_settings(PWNED_PASSWORDS={"API_ENDPOINT": "http://custom.endpoi.nt/"})
+    async def test_endpoint_override(self):
+        """
+        The custom API endpoint setting is honored.
+
+        """
+        api_client = api.PwnedPasswords()
+        self.assertEqual(api_client.api_endpoint, "http://custom.endpoi.nt/")
+
     def test_timeout(self):
         """
         Connection timeouts to the API are translated into a PwnedPasswordsError.


### PR DESCRIPTION
This pull request proposes adding a setting to configure the base URL of the PwnedPasswords API, which enables a use-case that I have for using this package together with a self-hosted instance of the API.

## Alternatives considered

Technically it's already possible to customize the API endpoint by overriding a class-level variable directly on the PwnedPasswords client as shown in the snippet below, but this approach to me seems unnecessarily brittle and splits configuration of the package into two locations (Django settings and code):

```py
##### current approach

from pwned_passwords_django import api

api.PwnedPasswords.api_endpoint = "http://custom.endpoi.nt/"
```

Instead, if this pull request is merged, a consumer of this package can simply configure the base URL in the Django settings:

```py
##### proposed approach

PWNED_PASSWORDS = {
    "API_ENDPOINT": "http://custom.endpoi.nt/",
}
```

## Implementation notes

The proposed implementation is a little bit round-about in overriding the value of the existing class-level `api_endpoint` variable in the constructor. I considered two alternative implementations (discussed below) but believe that there's larger downsides to each of them compared to the proposed implementation.

### Alternative 1: access setting in the class-level variable

Upsides:

* Most minimal change.

Downsides:

* Accessing settings is now split between constructor and class-initialization.
* Value is bound early (import time as opposed to run time) which may cause issues when overriding settings.

```diff
diff --git a/src/pwned_passwords_django/api.py b/src/pwned_passwords_django/api.py
index 19bdce1..3fdc405 100644
--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -61,7 +61,10 @@ class PwnedPasswords:
 
     """
 
-    api_endpoint: str = "https://api.pwnedpasswords.com/range/"
+    api_endpoint: str = getattr(settings, "PWNED_PASSWORDS", {}).get(
+        "API_ENDPOINT",
+        "https://api.pwnedpasswords.com/range/",
+    )
 
     user_agent: str = (
         f"pwned-passwords-django/{__version__} "
```

### Alternative 2: only initialize the setting in the constructor

Upsides:

* Avoids potential confusion having `api_endpoint` be defined on both the class-level and the instance-level.

Downsides:

* Technically a breaking change as a consumer of the package may depend on `api.PwnedPasswords.api_endpoint` existing as a class-level variable.

```diff
diff --git a/src/pwned_passwords_django/api.py b/src/pwned_passwords_django/api.py
index 19bdce1..3fc1e97 100644
--- a/src/pwned_passwords_django/api.py
+++ b/src/pwned_passwords_django/api.py
@@ -61,8 +61,6 @@ class PwnedPasswords:
 
     """
 
-    api_endpoint: str = "https://api.pwnedpasswords.com/range/"
-
     user_agent: str = (
         f"pwned-passwords-django/{__version__} "
         f"(Python/{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro} "
@@ -81,6 +79,10 @@ class PwnedPasswords:
         self.add_padding = settings_dict.get("ADD_PADDING", True)
         self.client = client or httpx.Client()
         self.async_client = async_client or httpx.AsyncClient()
+        self.api_endpoint = settings_dict.get(
+            "API_ENDPOINT",
+            "https://api.pwnedpasswords.com/range/",
+        )
 
     def _prepare_password(self, password: str) -> typing.Tuple[str, str]:
         """
```